### PR TITLE
Loosen required cabal-version

### DIFF
--- a/data-easy.cabal
+++ b/data-easy.cabal
@@ -18,7 +18,7 @@ build-type:          Simple
 -- extra-source-files:  
 
 -- Constraint on the version of Cabal needed to build this package.
-cabal-version:       >=1.18
+cabal-version:       >=1.10
 
 
 library


### PR DESCRIPTION
A higher lower-bound than `>= 1.10` is seldom needed,and if the build-type is Simple `cabal check` will warn if the lower bound is too low.

This fixes compilation on GHC 7.6 when using the stock cabal-install version.
